### PR TITLE
Enable cross compilation for applications

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,7 @@ ENV TARGETS="x86_64-unknown-linux-musl aarch64-unknown-linux-musl x86_64-unknown
 RUN rustup target add ${TARGETS}
 
 # needed for cargo-chef and cargo-sbom, as well as many other compilations
-RUN apk add musl-dev linux-headers make
-RUN cargo install cargo-chef@0.1.67 cargo-sbom@0.9.1
+RUN apk add musl-dev linux-headers make clang mold
+RUN cargo install cargo-chef cargo-sbom
+# we define target specific rustc flags for cross-compilation
+ADD config.toml /usr/local/cargo/

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,28 @@
+[target.aarch64-unknown-linux-musl]
+linker = "/usr/bin/clang"
+rustflags = [
+    "-C",
+    "link-arg=--ld-path=/usr/bin/mold",
+    "-C",
+    "link-arg=--target=aarch64-unknown-linux-musl",
+]
+
+[target.x86_64-unknown-linux-musl]
+linker = "/usr/bin/clang"
+rustflags = [
+    "-C",
+    "link-arg=--ld-path=/usr/bin/mold",
+    "-C",
+    "link-arg=--target=x86_64-unknown-linux-musl",
+]
+
+# FIXME: riscv64 is not yet available in rust:1.80.1-alpine3.20
+# but both clang and mold support it. Alos musl-dev is available in Alpine 3.20
+# [target.riscv64gc-unknown-linux-gnu]
+# linker = "/usr/bin/clang"
+# rustflags = [
+#     "-C",
+#     "link-arg=--ld-path=/usr/bin/mold",
+#     "-C",
+#     "link-arg=--target=riscv64-unknown-linux-musl",
+# ]


### PR DESCRIPTION
Even though rust can do cross-compilation, it cannot do linking for target platform. We have to define target specific rustc options and have required toolchain installed as well as libraries for target platfrom

clang is a very good choice for cross-compilation unless we are going to build for some exotic targets