### PR TITLE
no need for derived tags when building ephemeral images in CI

### DIFF
--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -41,6 +41,5 @@
             platforms: linux/amd64,linux/arm64
             push: false
             tags: |
-              ${{ github.event.pull_request.head.repo.full_name }}:${{ github.event.pull_request.head.ref }}
               ${{ github.event.pull_request.head.repo.full_name }}:latest
   


### PR DESCRIPTION
We were building in `prbuild.yaml` with the following tags:

```
              ${{ github.event.pull_request.head.repo.full_name }}:${{ github.event.pull_request.head.ref }}
              ${{ github.event.pull_request.head.repo.full_name }}:latest
```

These builds all get thrown away, for testing only. As long as the ref of the PR head is a valid tag, it worked. But if it isn't - and that can happen often - it failed. Since these are just getting thrown away, leave it as `latest` only.

In main build we use the actual commit, which always is a valid tag. And in release, we use semver. So those are fine.