### PR TITLE
Use git tag to tag docker image

### DIFF
--- a/.github/workflows/mainbuild.yaml
+++ b/.github/workflows/mainbuild.yaml
@@ -1,38 +1,36 @@
 ---
-    name: main build
-    on:
-      push:
-        branches:
-        - "main"
-        
-    
-    jobs:
-      build:
-        runs-on: ubuntu-latest
-        strategy:
-          fail-fast: false
-        steps:
-        - name: Starting Report
-          run: |
-              echo Git Ref: ${{ github.event.head_commit.id }}
-              echo GitHub Event: ${{ github.event_name }}
-              echo Disk usage
-              df -h
-              echo Memory
-              free -m
-        - uses: actions/checkout@v4
-          with:
-            fetch-depth: 0
-        - name: Set up QEMU
-          uses: docker/setup-qemu-action@v3
-        - name: Set up Docker Buildx
-          uses: docker/setup-buildx-action@v3
-        - uses: docker/build-push-action@v5
-          with:
-            context: .
-            platforms: linux/amd64,linux/arm64
-            push: false
-            tags: |
-              ${{ github.event.repository.full_name }}:${{ github.event.head_commit.id }}
-              ${{ github.event.repository.full_name }}:latest
-  
+name: main build
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Starting Report
+        run: |
+          echo Git Ref: ${{ github.event.head_commit.id }}
+          echo GitHub Event: ${{ github.event_name }}
+          echo Disk usage
+          df -h
+          echo Memory
+          free -m
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: |
+            ${{ github.event.repository.full_name }}:${{ github.event.head_commit.id }}
+            ${{ github.event.repository.full_name }}:latest

--- a/.github/workflows/mainbuild.yaml
+++ b/.github/workflows/mainbuild.yaml
@@ -7,8 +7,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      matrix:
+        os: [ubuntu-latest]
       fail-fast: false
     steps:
       - name: Starting Report

--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -1,45 +1,43 @@
 ---
-    name: PR build
-    on:
-      pull_request_target:
-        paths-ignore:
-          - '.github/workflows/**'
-        branches:
-          - "main"
-        
-    
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
-    
-    jobs:
-      build:
-        runs-on: ubuntu-latest
-        strategy:
-          fail-fast: false
-        steps:
-        - name: Starting Report
-          run: |
-              echo Git Ref: ${{ github.event.pull_request.head.ref  }}
-              echo GitHub Event: ${{ github.event_name }}
-              echo Disk usage
-              df -h
-              echo Memory
-              free -m
-        - uses: actions/checkout@v4
-          with:
-            repository: ${{ github.event.pull_request.head.repo.full_name }}
-            ref: ${{ github.event.pull_request.head.ref }}
-            fetch-depth: 0
-        - name: Set up QEMU
-          uses: docker/setup-qemu-action@v3
-        - name: Set up Docker Buildx
-          uses: docker/setup-buildx-action@v3
-        - uses: docker/build-push-action@v5
-          with:
-            context: .
-            platforms: linux/amd64,linux/arm64
-            push: false
-            tags: |
-              ${{ github.event.pull_request.head.repo.full_name }}:latest
-  
+name: PR build
+on:
+  pull_request_target:
+    paths-ignore:
+      - ".github/workflows/**"
+    branches:
+      - "main"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Starting Report
+        run: |
+          echo Git Ref: ${{ github.event.pull_request.head.ref  }}
+          echo GitHub Event: ${{ github.event_name }}
+          echo Disk usage
+          df -h
+          echo Memory
+          free -m
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: |
+            ${{ github.event.pull_request.head.repo.full_name }}:latest

--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -13,8 +13,10 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      matrix:
+        os: [ubuntu-latest]
       fail-fast: false
     steps:
       - name: Starting Report

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
             echo "Tag $TAG does not match RUST_VERSION $RUST_VERSION"
             exit 1
           fi
-          echo "::set-output name=RUST_VERSION::$RUST_VERSION"
+          echo "IMAGE_TAG=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
       - name: Login to Docker Hub
         if: ${{ github.event.repository.full_name }} == 'lf-edge/eve-rust'
         uses: docker/login-action@v3
@@ -54,5 +54,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ env.OCIREPO }}:${{ steps.rust_version.outputs.RUST_VERSION }}
+            ${{ env.OCIREPO }}:${{ steps.rust_version.outputs.IMAGE_TAG }}
             ${{ env.OCIREPO }}:latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,8 +12,10 @@ env:
 
 jobs:
   build_and_push:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      matrix:
+        os: [ubuntu-latest]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+"
       - "[0-9]+.[0-9]+.[0-9]+-[0-9]+"
     paths-ignore:
-      - '.github/workflows/**'
+      - ".github/workflows/**"
 
 env:
   OCIREPO: lfedge/eve-rust
@@ -16,41 +16,41 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - name: Get rust version
-      id: rust_version
-      run: |
-        RUST_VERSION=$(awk  -F= '/ARG RUST_VERSION/ {print $2}' Dockerfile)
-        # make sure we got a rust version
-        if [ -z "$RUST_VERSION" ]; then
-          echo "Failed to get RUST_VERSION"
-          exit 1
-        fi
-        # strip off any potential eve-specific extensions to the tag
-        TAG="${{ github.ref_name }}"
-        TAG="${TAG%%-*}"
-        if [ "$TAG" != "$RUST_VERSION" ]; then
-          echo "Tag $TAG does not match RUST_VERSION $RUST_VERSION"
-          exit 1
-        fi
-        echo "::set-output name=RUST_VERSION::$RUST_VERSION"
-    - name: Login to Docker Hub
-      if: ${{ github.event.repository.full_name }} == 'lf-edge/eve-rust'
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
-        password: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-    - uses: docker/build-push-action@v5
-      with:
-        context: .
-        platforms: linux/amd64,linux/arm64
-        push: true
-        tags: |
-          ${{ env.OCIREPO }}:${{ steps.rust_version.outputs.RUST_VERSION }}
-          ${{ env.OCIREPO }}:latest
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Get rust version
+        id: rust_version
+        run: |
+          RUST_VERSION=$(awk  -F= '/ARG RUST_VERSION/ {print $2}' Dockerfile)
+          # make sure we got a rust version
+          if [ -z "$RUST_VERSION" ]; then
+            echo "Failed to get RUST_VERSION"
+            exit 1
+          fi
+          # strip off any potential eve-specific extensions to the tag
+          TAG="${{ github.ref_name }}"
+          TAG="${TAG%%-*}"
+          if [ "$TAG" != "$RUST_VERSION" ]; then
+            echo "Tag $TAG does not match RUST_VERSION $RUST_VERSION"
+            exit 1
+          fi
+          echo "::set-output name=RUST_VERSION::$RUST_VERSION"
+      - name: Login to Docker Hub
+        if: ${{ github.event.repository.full_name }} == 'lf-edge/eve-rust'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.RELEASE_DOCKERHUB_ACCOUNT }}
+          password: ${{ secrets.RELEASE_DOCKERHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.OCIREPO }}:${{ steps.rust_version.outputs.RUST_VERSION }}
+            ${{ env.OCIREPO }}:latest


### PR DESCRIPTION
Rust version is incorrectly used to tag docker image. So 1.84.1-1 is tagged as 1.84.1 and overwrote the image!
We need to re-tag 1.84.1, 1.84.1-1 
Also re-tag 1.85.1 becasue 'latest' is also moved