### PR TITLE
ci: cross-compile + qemu-run smoketest for all musl targets

### DIFF
--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -11,13 +11,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+env:
+  # PR-scoped local image tag used by the smoketest job after hydrating
+  # from the GHA buildx cache written by the build job.
+  CI_IMAGE: eve-rust-ci:pr-${{ github.event.pull_request.number }}
+
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-      fail-fast: false
+    runs-on: ubuntu-latest
     steps:
       - name: Starting Report
         run: |
@@ -36,6 +37,8 @@ jobs:
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+      # Validates the Dockerfile builds for both host arches, and populates
+      # the GHA buildx cache that the smoketest job rehydrates from.
       - uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7.0.0
         with:
           context: .
@@ -43,3 +46,39 @@ jobs:
           push: false
           tags: |
             ${{ github.event.pull_request.head.repo.full_name }}:latest
+          cache-to: type=gha,mode=max
+          cache-from: type=gha
+
+  smoketest:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+      # Pull the amd64 image from the GHA cache written by the build job
+      # and load it into the local docker daemon so `docker run` in run.sh
+      # can see it. All layers are cache hits — this step is effectively
+      # just the --load export.
+      - name: Hydrate eve-rust image from build cache
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7.0.0
+        with:
+          context: .
+          platforms: linux/amd64
+          load: true
+          tags: ${{ env.CI_IMAGE }}
+          cache-from: type=gha
+      # Regression test: cross-compile the smoketest crate for each supported
+      # musl target, assert ELF arch, then run each binary under qemu-user.
+      # Catches silent cross-compile breakage of the kind we hit enabling
+      # riscv64 (wrong-arch libc picked up from host /usr/lib, tier-3 target
+      # spec missing crt-static-default, etc).
+      - name: Run smoketest
+        env:
+          RUST_IMAGE: ${{ env.CI_IMAGE }}
+        run: ./test/smoketest/run.sh

--- a/.github/workflows/prbuild.yaml
+++ b/.github/workflows/prbuild.yaml
@@ -1,11 +1,18 @@
 ---
 name: PR build
 on:
-  pull_request_target:
+  pull_request:
     paths-ignore:
       - ".github/workflows/**"
     branches:
       - "main"
+
+# This workflow does not push or consume any secrets, so `pull_request`
+# (not `pull_request_target`) is appropriate: fork PRs still build but
+# their GITHUB_TOKEN is read-only and secrets aren't exposed, which
+# matters because the smoketest job runs a script from the PR tree.
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -19,6 +26,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Starting Report
         run: |
@@ -30,33 +38,29 @@ jobs:
           free -m
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
       # Validates the Dockerfile builds for both host arches, and populates
-      # the GHA buildx cache that the smoketest job rehydrates from.
+      # the GHA buildx cache that the smoketest job rehydrates from. The
+      # tag is purely local — nothing pushes or loads this image.
       - uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7.0.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: false
-          tags: |
-            ${{ github.event.pull_request.head.repo.full_name }}:latest
+          tags: eve-rust-ci:multiarch
           cache-to: type=gha,mode=max
           cache-from: type=gha
 
   smoketest:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
       - name: Set up Docker Buildx

--- a/test/smoketest/.gitignore
+++ b/test/smoketest/.gitignore
@@ -1,0 +1,3 @@
+/target/
+/Cargo.lock
+/.cargo/

--- a/test/smoketest/Cargo.toml
+++ b/test/smoketest/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "eve-rust-smoketest"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[[bin]]
+name = "smoketest"
+path = "src/main.rs"

--- a/test/smoketest/cargo-config.toml
+++ b/test/smoketest/cargo-config.toml
@@ -1,0 +1,15 @@
+# Shape matches what real consumers (e.g. EVE's pkg/vector) use: profile
+# settings plus per-cfg rustflags that merge with the base image's
+# [target.<triple>] entries in /usr/local/cargo/config.toml.
+
+[profile.release]
+opt-level = "z"
+lto = "fat"
+codegen-units = 1
+strip = "symbols"
+
+[target.'cfg(target_env = "musl")']
+rustflags = [
+    "-C", "embed-bitcode=yes",
+    "-A", "dead_code",
+]

--- a/test/smoketest/run.sh
+++ b/test/smoketest/run.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Regression test for the eve-rust toolchain image:
+#   - cross-compile a tiny crate for all three supported musl targets using
+#     $RUST_IMAGE as the toolchain
+#   - assert each resulting ELF has the expected machine type
+#   - execute each binary under qemu-user (via binfmt_misc) to prove it
+#     actually runs, not just links
+#
+# Used both locally and in the eve-rust CI pipeline. For non-amd64 execution
+# the caller is responsible for registering qemu handlers
+# (docker/setup-qemu-action in CI, `docker run --privileged tonistiigi/binfmt
+# --install all` locally).
+
+set -euo pipefail
+
+RUST_IMAGE="${RUST_IMAGE:-lfedge/eve-rust:latest}"
+cd "$(dirname "$0")"
+
+declare -A TARGETS=(
+  [amd64]=x86_64-unknown-linux-musl
+  [arm64]=aarch64-unknown-linux-musl
+  [riscv64]=riscv64gc-unknown-linux-musl
+)
+
+declare -A EXPECTED_MACHINE=(
+  [amd64]="Advanced Micro Devices X86-64"
+  [arm64]="AArch64"
+  [riscv64]="RISC-V"
+)
+
+# Build all three targets in one invocation of the rust container, reusing
+# the target/ cache across them. We `docker run` directly (no buildx) so a
+# just-loaded local image like `eve-rust-ci:pr` is visible without pushing
+# to a registry.
+echo "=== Cross-compiling smoketest for all 3 targets ==="
+docker run --rm \
+  -v "$(pwd):/app" \
+  -w /app \
+  "${RUST_IMAGE}" \
+  sh -c '
+    set -eu
+    mkdir -p .cargo
+    cp cargo-config.toml .cargo/config.toml
+    for t in x86_64-unknown-linux-musl aarch64-unknown-linux-musl riscv64gc-unknown-linux-musl; do
+      echo "--- compile: $t ---"
+      CARGO_BUILD_TARGET=$t cargo build --release
+    done
+  '
+
+fail=0
+for arch in amd64 arm64 riscv64; do
+  target="${TARGETS[$arch]}"
+  expected_machine="${EXPECTED_MACHINE[$arch]}"
+  binary="target/${target}/release/smoketest"
+
+  echo
+  echo "================ $target  ($arch) ================"
+
+  if [ ! -f "$binary" ]; then
+    echo "FAIL: $binary was not produced"
+    fail=1
+    continue
+  fi
+
+  # readelf is provided by binutils (preinstalled on ubuntu-latest); fall
+  # back to running it inside the rust image if missing.
+  if command -v readelf >/dev/null 2>&1; then
+    elf_hdr=$(readelf -h "$binary")
+  else
+    elf_hdr=$(docker run --rm -v "$(pwd):/app" -w /app "${RUST_IMAGE}" llvm-readelf -h "$binary")
+  fi
+  echo "$elf_hdr" | grep -E "Class|Data|Machine|Type"
+
+  actual_machine=$(echo "$elf_hdr" | awk -F: '/Machine:/ {sub(/^ +/, "", $2); print $2}')
+  if [ "$actual_machine" != "$expected_machine" ]; then
+    echo "FAIL: $arch has ELF Machine=\"${actual_machine}\", expected \"${expected_machine}\""
+    fail=1
+    continue
+  fi
+
+  # Execute the binary inside a matching-arch alpine container. Docker plus
+  # binfmt_misc routes through qemu-user for non-host arches.
+  if docker run --rm --platform="linux/${arch}" -v "$(pwd):/app" -w /app alpine:3.22 "./${binary}"; then
+    echo "PASS: $arch"
+  else
+    rc=$?
+    echo "FAIL: $arch (exit $rc)"
+    fail=1
+  fi
+done
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "All three targets linked, are the correct arch, and ran under qemu-user."
+else
+  echo "One or more targets failed." >&2
+  exit 1
+fi

--- a/test/smoketest/src/main.rs
+++ b/test/smoketest/src/main.rs
@@ -1,0 +1,12 @@
+use std::collections::HashMap;
+
+fn main() {
+    let mut m: HashMap<&str, u32> = HashMap::new();
+    m.insert("riscv64", 64);
+    m.insert("musl", 1);
+    for (k, v) in &m {
+        println!("{k} = {v}");
+    }
+    assert_eq!(m.values().sum::<u32>(), 65);
+    println!("ok");
+}


### PR DESCRIPTION
## Summary

Adds a regression test that catches silent toolchain breakage of the sort we hit while wiring up riscv64: wrong-arch CRT files picked up from the amd64 host, tier-3 target spec missing `crt-static-default`, bitcode missing from `std` for downstream fat-LTO, etc. The symptoms were cryptic linker errors from mold/clang deep inside a consumer's build; catching them at image-build time is much cheaper.

## What's new

`test/smoketest/` is a tiny Cargo crate whose release profile mirrors the shape real consumers use (fat LTO, embed-bitcode, strip, `cfg(target_env = "musl")` rustflags that merge with the base image's `[target.<triple>]` entries in `/usr/local/cargo/config.toml`).

`test/smoketest/run.sh`:

- Cross-compiles the crate for `x86_64` / `aarch64` / `riscv64gc` musl in a single `docker run` against the image under test (one cargo invocation, one `target/` cache, three `CARGO_BUILD_TARGET` iterations).
- Asserts each resulting ELF has the expected `Machine` value via `readelf`.
- Executes each binary under `docker run --platform=linux/<arch>` so qemu-user via `binfmt_misc` actually runs it — proves the produced binary is not only well-formed but functional.

We `docker run` the image directly rather than going through buildx, because buildx's docker-container driver can't see images that only live in the local docker daemon; buildx there would force pushing to a registry service just to re-pull.

## Workflow shape

Split into two jobs with shared GHA buildx cache:

- **`build`** — existing multi-arch (linux/amd64 + linux/arm64) Dockerfile check, now with `cache-to: type=gha,mode=max`.
- **`smoketest`** — `needs: build`. Rehydrates the amd64 image from the GHA cache via `docker/build-push-action` with `load: true` + `cache-from: type=gha` (all layers hit cache, so the step is effectively just the `--load` export), tags it `eve-rust-ci:pr-${PR_NUMBER}`, then runs `run.sh`.

## Security / robustness

Second commit hardens the workflow:

- Switched trigger from `pull_request_target` to `pull_request`. The workflow neither pushes nor consumes secrets, so `pull_request_target` was pure exposure — and the smoketest now executes a script from the PR tree, which under `_target` would run with write-scope `GITHUB_TOKEN` and secrets access.
- Added workflow-level `permissions: contents: read` as belt-and-suspenders.
- Added `timeout-minutes` to both jobs (qemu-user riscv64 can hang).

## Merge ordering

This PR is standalone; it doesn't require the riscv64 toolchain changes to land first. But on current `main`, the smoketest's riscv64 step will fail because `main`'s `eve-rust` image doesn't yet ship a riscv64 std. The intended sequence is **this PR first**, then rebase the riscv support PR on top — the rebased riscv PR will contain both the test infra and the riscv toolchain, and CI will pass all three targets end-to-end.

## Test plan

- [x] Local: `RUST_IMAGE=mikemzed/eve-rust:1.93.1-14 ./test/smoketest/run.sh` passes all three targets (x86_64, aarch64, riscv64).
- [x] Local: `docker buildx build --load --platform=linux/amd64 -t eve-rust-ci:pr .` + `RUST_IMAGE=eve-rust-ci:pr ./test/smoketest/run.sh` mirrors the CI flow end-to-end.
- [ ] GHA: observe the split-job pipeline run against this PR (expected: riscv64 target fails until the riscv toolchain PR lands and is rebased in).